### PR TITLE
Perform issuer operations without accessing tails file

### DIFF
--- a/src/amcl.rs
+++ b/src/amcl.rs
@@ -377,6 +377,14 @@ impl GroupOrderElement {
         })
     }
 
+    pub fn zero() -> ClResult<GroupOrderElement> {
+        Ok(GroupOrderElement { bn: BIG::new() })
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.bn.iszilch()
+    }
+
     pub fn new_from_seed(seed: &[u8]) -> ClResult<GroupOrderElement> {
         // returns random element in 0, ..., GroupOrder-1
         if seed.len() != MODBYTES {
@@ -412,16 +420,10 @@ impl GroupOrderElement {
     pub fn sub_mod(&self, r: &GroupOrderElement) -> ClResult<GroupOrderElement> {
         //need to use modneg if sub is negative
         let mut diff = self.bn;
-        diff.sub(&r.bn);
-        let mut zero = BIG::new();
-        zero.zero();
-
-        if diff < zero {
-            return Ok(GroupOrderElement {
-                bn: BIG::modneg(&diff, &BIG::new_ints(&CURVE_ORDER)),
-            });
+        if diff < r.bn {
+            diff = BIG::modneg(&diff, &BIG::new_ints(&CURVE_ORDER));
         }
-
+        diff.sub(&r.bn);
         Ok(GroupOrderElement { bn: diff })
     }
 

--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(feature = "openssl_bn", path = "openssl.rs")]
-// #[cfg_attr(not(feature = "openssl_bn"), path = "rust.rs")]
+#[cfg_attr(not(feature = "openssl_bn"), path = "rust.rs")]
 mod inner;
 
 pub use inner::*;

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -756,7 +756,7 @@ impl Issuer {
         Ok(rev_reg_delta)
     }
 
-    pub fn _update_revocation_accumulator(
+    pub(crate) fn _update_revocation_accumulator(
         accum: PointG2,
         max_cred_num: u32,
         updates: impl IntoIterator<Item = (u32, bool)>,


### PR DESCRIPTION
A revocation witness is now created during the issuance process, which matches the usual pattern of usage, and is much faster for the issuer to create than for the prover.

Large updates to the revocation registry may be faster depending on I/O speed (which is no longer a factor).