### PR TITLE
Tails and accumulator refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "ee5cca1ddc8b9dceb55b7f1272a9d1e643d73006f350a20ab4926d24e33f0f0d"
 
 [[package]]
 name = "anoncreds-clsignatures"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "amcl",
  "glass_pumpkin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "anoncreds-clsignatures"
 readme = "README.md"
 repository = "https://github.com/hyperledger/anoncreds-clsignatures-rs"
-version = "0.2.0"
+version = "0.2.1"
 rust-version = "1.63"
 
 [lib]

--- a/src/amcl.rs
+++ b/src/amcl.rs
@@ -435,6 +435,12 @@ impl GroupOrderElement {
         })
     }
 
+    pub fn new_u32(val: u32) -> ClResult<GroupOrderElement> {
+        Ok(GroupOrderElement {
+            bn: BIG::new_int(val as isize),
+        })
+    }
+
     pub fn zero() -> ClResult<GroupOrderElement> {
         Ok(GroupOrderElement { bn: BIG::new() })
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -516,7 +516,7 @@ pub fn create_tau_list_expected_values(
     )?;
     let t4 = Pair::pair2(
         &proof_c.g,
-        &rev_reg.accum.0,
+        &rev_reg.accum.as_ref(),
         &r_pub_key.g.neg()?,
         &proof_c.w,
     )?
@@ -585,7 +585,7 @@ pub fn create_tau_list_values(
     )?;
     let t4 = Pair::pair2(
         &r_pub_key.htilde.mul(&params.r)?,
-        &rev_reg.accum.0,
+        &rev_reg.accum.as_ref(),
         &r_pub_key.g.mul(&params.r_prime)?.neg()?,
         &r_pub_key.h_cap,
     )?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -763,7 +763,7 @@ impl Prover {
 
         let z_calc = Pair::pair2(
             &r_cred.witness_signature.g_i,
-            &rev_reg.accum.0,
+            &rev_reg.accum.as_ref(),
             &cred_rev_pub_key.g.neg()?,
             &witness.omega.0,
         )?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -548,6 +548,12 @@ impl RevocationRegistry {
     }
 }
 
+impl From<Accumulator> for RevocationRegistry {
+    fn from(accum: Accumulator) -> RevocationRegistry {
+        RevocationRegistry { accum }
+    }
+}
+
 impl From<RevocationRegistryDelta> for RevocationRegistry {
     fn from(rev_reg_delta: RevocationRegistryDelta) -> RevocationRegistry {
         RevocationRegistry {


### PR DESCRIPTION
Adds wrappers around the Accumulator and Tail types instead of exposing PointG2 (no compatiblity change for indy-credx or anoncreds-rs).

Adds utility methods to RevocationRegistry for generating the initial state and a future state with a set of issued indexes, for use in anoncreds-rs.