### PR TITLE
Reject missing attribute when signing or processing credential

### DIFF
--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -1608,7 +1608,7 @@ mod tests {
             prover_mocks::blinded_credential_secrets_correctness_proof(),
         );
         let mut cred_values = mocks::credential_values();
-        cred_values.attrs_values.pop_first();
+        cred_values.attrs_values.remove("age");
 
         let credential_issuance_nonce = mocks::credential_issuance_nonce();
         assert!(Issuer::sign_credential(

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -682,6 +682,16 @@ impl Prover {
         }) {
             return Err(err_msg!("Value by key '{}' not found in public key", attr));
         }
+        if let Some((ref attr, _)) = p_pub_key
+            .r
+            .iter()
+            .find(|(attr, _)| !cred_values.attrs_values.contains_key(attr.as_str()))
+        {
+            return Err(err_msg!(
+                "Credential attribute '{}' value not provided",
+                attr
+            ));
+        }
 
         let rx = cred_values
             .attrs_values


### PR DESCRIPTION
Verified that these credentials are rejected when added to a proof builder with `add_sub_proof_request`, but it was still possible to issue and process them.

Fixes #20