### PR TITLE
Ensure revocation index is in range

### DIFF
--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -1341,6 +1341,10 @@ impl Issuer {
                secret!(rev_idx), secret!(cred_context), blinded_credential_secrets, cred_pub_key, secret!(cred_priv_key), max_cred_num,
                issuance_by_default, rev_reg, secret!(rev_key_priv));
 
+        if rev_idx == 0 || rev_idx > max_cred_num {
+            return Err(err_msg!("Revocation index is outside of valid range"));
+        }
+
         let ur = blinded_credential_secrets
             .ur
             .ok_or_else(|| err_msg!("No revocation part present in blinded master secret."))?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -650,6 +650,10 @@ impl Prover {
         trace!("Prover::_process_non_revocation_credential: >>> r_cred: {:?}, vr_prime: {:?}, cred_rev_pub_key: {:?}, rev_reg: {:?}, rev_key_pub: {:?}",
                r_cred, vr_prime, cred_rev_pub_key, rev_reg, rev_key_pub);
 
+        if r_cred.i == 0 {
+            return Err(err_msg!("Invalid revocation index"));
+        }
+
         let r_cnxt_m2 = BigNumber::from_bytes(&r_cred.m2.to_bytes()?)?;
         r_cred.vr_prime_prime = vr_prime.add_mod(&r_cred.vr_prime_prime)?;
         Prover::_test_witness_signature(


### PR DESCRIPTION
For the issuer, this ensures that `rev_idx` is in range, to avoid issuing invalid credentials. Previously this could issue an invalid credential with the index `0`, or panic due to an overflow for values greater than `max_cred_num`.

For the prover, this checks that the revocation index is not zero when processing a credential (`max_cred_num` is not available here without changing the API).