### PR TITLE
Use default BigNumContext to be compatible with old openssl.

### DIFF
--- a/src/bn/openssl.rs
+++ b/src/bn/openssl.rs
@@ -27,7 +27,7 @@ pub struct BigNumber {
 
 impl BigNumber {
     pub fn new_context() -> ClResult<BigNumberContext> {
-        let ctx = BigNumContext::new_secure()?;
+        let ctx = BigNumContext::new()?;
         Ok(BigNumberContext {
             openssl_bn_context: ctx,
         })


### PR DESCRIPTION
As far as I noticed, this is the only place incompatible with some old OpenSSL versions.
Is it OK to roll back this change to the Ursa code version? 

I don't see another usage of the secure OpenSSL heap, so I doubt the value of this particular call of `new_secure`.
Right next call (BN::new() ) uses the default heap, so I'm confused about this inconsistency.

Please let me know if I missed some critical details.