### PR TITLE
Add checks to quadratic residue sampling

### DIFF
--- a/src/bn/openssl.rs
+++ b/src/bn/openssl.rs
@@ -528,7 +528,18 @@ impl BigNumber {
     }
 
     pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
-        let qr = n.rand_range()?.sqr(None)?.modulus(n, None)?;
+        
+        let mut sqr_candidate = n.rand_range()?;
+        let big_one = BigNumber::from_u32(1)?;
+
+        // Number sqr_candidate to square must be between 1 and n-1 and
+        // have gcd(sqr_candidate,n)=1
+        while Self::gcd(&sqr_candidate, n, None)? != big_one {
+                sqr_candidate = n.rand_range()?;
+        }
+
+        let qr = sqr_candidate.sqr(None)?.modulus(n, None)?;
+
         Ok(qr)
     }
 


### PR DESCRIPTION
To sample a quadratic residue mod n uniformly at random, one technique is to sample an integer between 1 and n-1, check that it is invertible, and square it, e.g. see [here](https://www.inf.ufpr.br/murilo/public/IndexingPaper.pdf).

The added code ensures the randomly-sampled element that gets squared is invertible (which also implies it is non-zero, so no need to check it is non-zero separately).

In normal usage of this function for AnonCreds, n = p \* q where p and q are large primes, so the probability that an element is not invertible is only 1 - (p-1)\*(q-1) / (p\*q) = 1/p + 1/q - 1/(p\*q), which means the expectation on the number of iterations of the while loop is very close to 1.

(Now with DCO!)