### PR TITLE
Add check to generation of s in issuer public key

### DIFF
--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -282,6 +282,40 @@ mod tests {
         assert_eq!(num.lshift1().unwrap(), BigNumber::from_u32(2000).unwrap());
     }
 
+    #[test]
+    fn generates_semiprime_subgroup_works() {
+        let p_prime = BigNumber::from_dec("9056990664109556783").unwrap();
+        let q_prime = BigNumber::from_dec("7256373851099466689").unwrap();
+
+        // n = (2 * p' + 1) * (2 * q' + 1)
+        let n = BigNumber::from_dec("262883640898786323684721809348268052893").unwrap();
+
+        // Since n is a safe RSA modulus, the group of invertible
+        // quadratic residues QR*_n has order p'*q'
+
+        // 4 = 2^2 so it is a quadratic residue mod n, and it is
+        // invertible mod n since 4 is coprime with n.  Its order in
+        // QR*_n is not 1, p' or q' (can check with WolframAlpha), so
+        // it must be p'*q' by Lagrange and hence it is primitive in
+        // QR*_n.
+        let mut a = BigNumber::from_dec("4").unwrap();
+        assert_eq!(
+            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n),
+            Ok(true)
+        );
+
+        // 4^q' = (+-(2^q'))^2 so it is a quadratic residue mod n, and
+        // it is invertible mod n since 4 is coprime with n. Its order
+        // in QR*_n is not 1, and is at most p' since (4^q')^p' =
+        // 4^(p'*q') = 1, so its order must be p' by Lagrange and
+        // hence it is not primitive in QR*_n
+        a = BigNumber::from_dec("83826306846185295424745260846198095936").unwrap();
+        assert_eq!(
+            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n),
+            Ok(false)
+        );
+    }
+
     #[cfg(feature = "serde")]
     #[derive(Serialize, Deserialize)]
     struct Test {

--- a/src/bn/openssl.rs
+++ b/src/bn/openssl.rs
@@ -527,6 +527,32 @@ impl BigNumber {
         Ok(bn)
     }
 
+    pub fn generates_semiprime_subgroup(
+        &self,
+        p_prime: &BigNumber,
+        q_prime: &BigNumber,
+        n: &BigNumber,
+    ) -> ClResult<bool> {
+        // Returns true if and only if self is a generator for a
+        // multiplicative subgroup of the integers mod n of order
+        // p'*q' where n = (2p' + 1) * (2q' + 1)
+
+        // Can be used to check if an invertible quadratic residue of
+        // an RSA modulus n is a generator for the whole group of
+        // invertible quadratic residues mod n
+
+        let big_one = BigNumber::from_u32(1)?;
+
+        if self == &big_one
+            || self.mod_exp(p_prime, &n, None)? == big_one
+            || self.mod_exp(q_prime, &n, None)? == big_one
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
     pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
         let qr = n.rand_range()?.sqr(None)?.modulus(n, None)?;
         Ok(qr)

--- a/src/bn/rust.rs
+++ b/src/bn/rust.rs
@@ -382,6 +382,32 @@ impl BigNumber {
         self.mul(&b.inverse(&p, None)?, None)?.modulus(&p, None)
     }
 
+    pub fn generates_semiprime_subgroup(
+        &self,
+        p_prime: &BigNumber,
+        q_prime: &BigNumber,
+        n: &BigNumber,
+    ) -> ClResult<bool> {
+        // Returns true if and only if self is a generator for a
+        // multiplicative subgroup of the integers mod n of order
+        // p'*q' where n = (2p' + 1) * (2q' + 1)
+
+        // Can be used to check if an invertible quadratic residue of
+        // an RSA modulus n is a generator for the whole group of
+        // invertible quadratic residues mod n
+
+        let big_one = BigNumber::from_u32(1)?;
+
+        if self == &big_one
+            || self.mod_exp(p_prime, &n, None)? == big_one
+            || self.mod_exp(q_prime, &n, None)? == big_one
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
     pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
         let qr = n.rand_range()?.sqr(None)?.modulus(&n, None)?;
         Ok(qr)

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -844,7 +844,11 @@ impl Issuer {
         let q = q_safe.rshift1()?;
 
         let n = p_safe.mul(&q_safe, Some(&mut ctx))?;
-        let s = random_qr(&n)?;
+        let mut s = random_qr(&n)?;
+        while !s.generates_semiprime_subgroup(&p, &q, &n)? {
+            s = random_qr(&n)?;
+        }
+
         let xz = gen_x(&p, &q)?;
 
         let mut xr = HashMap::new();


### PR DESCRIPTION
The implementation uses the method described in p24 of [this CL paper](https://eprint.iacr.org/2010/496.pdf#page=24) when generating the issuer public key, which involves sampling a random quadratic residue S and from that computing random powers to generate additional residues.  However, as stipulated in the paper, this method only works if S is a generator of the group of invertible quadratic residues mod n. This can be checked by verifying that it has order equal to the product of the Sophie-Germain primes p' and q' used to construct the safe RSA modulus n, but this check is not done  in the implementation.

Since p' and q' are coprime and are primes, every invertible quadratic residue has order 1, p', q' or p'\*q'.  It therefore suffices to check that S is not 1, that S^p' is not 1 mod n, and S^q' is not 1 mod n.

Added this check in a separate PR from my other one but both need to be integrated - hope it makes sense!