### PR TITLE
Bignum cleanups: remove code duplication and bignum context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -362,18 +362,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/bn/mod.rs
+++ b/src/bn/mod.rs
@@ -17,7 +17,6 @@ impl BigNumber {
     pub fn generate_prime_in_range(
         size_bits: usize,
         range_bits: usize,
-        mut ctx: Option<&mut BigNumberContext>,
     ) -> Result<BigNumber, Error> {
         trace!("bn::_generate_prime_in_range: >>> size: {size_bits}, range: {range_bits}",);
 
@@ -49,7 +48,7 @@ impl BigNumber {
             buf[0] |= 1 << size_top_bits;
 
             let res = BigNumber::from_bytes(&buf)?;
-            if res.is_prime(_reborrow_option(&mut ctx))? {
+            if res.is_prime()? {
                 debug!("Found prime in {iteration} iterations");
                 break res;
             }
@@ -68,7 +67,6 @@ impl BigNumber {
         p_prime: &BigNumber,
         q_prime: &BigNumber,
         n: &BigNumber,
-        mut ctx: Option<&mut BigNumberContext>,
     ) -> Result<bool, Error> {
         // Returns true if and only if self is a generator for a
         // multiplicative subgroup of the integers mod n of order
@@ -79,12 +77,8 @@ impl BigNumber {
         // invertible quadratic residues mod n
 
         if self.eq(&BIGNUMBER_1)
-            || self
-                .mod_exp(p_prime, &n, _reborrow_option(&mut ctx))?
-                .eq(&BIGNUMBER_1)
-            || self
-                .mod_exp(q_prime, &n, _reborrow_option(&mut ctx))?
-                .eq(&BIGNUMBER_1)
+            || self.mod_exp(p_prime, &n)?.eq(&BIGNUMBER_1)
+            || self.mod_exp(q_prime, &n)?.eq(&BIGNUMBER_1)
         {
             return Ok(false);
         }
@@ -92,28 +86,19 @@ impl BigNumber {
         Ok(true)
     }
 
-    pub fn random_qr(
-        n: &BigNumber,
-        mut ctx: Option<&mut BigNumberContext>,
-    ) -> Result<BigNumber, Error> {
+    pub fn random_qr(n: &BigNumber) -> Result<BigNumber, Error> {
         let mut sqr_candidate = n.rand_range()?;
 
         // Number sqr_candidate to square must be between 1 and n-1 and
         // have gcd(sqr_candidate,n)=1
-        while BigNumber::gcd(&sqr_candidate, n, _reborrow_option(&mut ctx))?.ne(&BIGNUMBER_1) {
+        while BigNumber::gcd(&sqr_candidate, n)?.ne(&BIGNUMBER_1) {
             sqr_candidate = n.rand_range()?;
         }
 
-        let qr = sqr_candidate
-            .sqr(_reborrow_option(&mut ctx))?
-            .modulus(n, ctx)?;
+        let qr = sqr_candidate.sqr()?.modulus(n)?;
 
         Ok(qr)
     }
-}
-
-fn _reborrow_option<'a, 'b: 'a, T>(opt: &'a mut Option<&'b mut T>) -> Option<&'a mut T> {
-    opt.as_mut().map(|o| &mut **o)
 }
 
 #[cfg(test)]
@@ -130,64 +115,61 @@ mod tests {
     fn exp_works() {
         let test = BigNumber::from_u32(3)
             .unwrap()
-            .exp(&BigNumber::from_u32(2).unwrap(), None)
+            .exp(&BigNumber::from_u32(2).unwrap())
             .unwrap();
         assert_eq!(BigNumber::from_u32(9).unwrap(), test);
 
         let test = BigNumber::from_u32(3)
             .unwrap()
-            .exp(&BigNumber::from_u32(3).unwrap(), None)
+            .exp(&BigNumber::from_u32(3).unwrap())
             .unwrap();
         assert_eq!(BigNumber::from_u32(27).unwrap(), test);
 
         let test = BigNumber::from_u32(2)
             .unwrap()
-            .exp(&BigNumber::from_u32(16).unwrap(), None)
+            .exp(&BigNumber::from_u32(16).unwrap())
             .unwrap();
         assert_eq!(BigNumber::from_u32(65536).unwrap(), test);
 
         let answer = BigNumber::from_dec("259344723055062059907025491480697571938277889515152306249728583105665800713306759149981690559193987143012367913206299323899696942213235956742929677132122730441323862712594345230336").unwrap();
         let test = BigNumber::from_u32(2)
             .unwrap()
-            .exp(&BigNumber::from_u32(596).unwrap(), None)
+            .exp(&BigNumber::from_u32(596).unwrap())
             .unwrap();
         assert_eq!(answer, test);
     }
 
     #[test]
     fn inverse_works() {
-        let mut ctx = BigNumber::new_context().unwrap();
         let mut bn = BigNumber::from_u32(3).unwrap();
         assert_eq!(
             BigNumber::from_u32(16).unwrap(),
-            bn.inverse(&BigNumber::from_u32(47).unwrap(), Some(&mut ctx))
-                .unwrap()
+            bn.inverse(&BigNumber::from_u32(47).unwrap()).unwrap()
         );
         bn = BigNumber::from_u32(9).unwrap();
         assert_eq!(
             BigNumber::from_u32(3).unwrap(),
-            bn.inverse(&BigNumber::from_u32(13).unwrap(), Some(&mut ctx))
-                .unwrap()
+            bn.inverse(&BigNumber::from_u32(13).unwrap()).unwrap()
         );
 
         let modulus = BigNumber::generate_prime(128).unwrap();
         let one = BigNumber::from_u32(1).unwrap();
         for _ in 0..25 {
             let r = BigNumber::rand(128).unwrap();
-            let s = r.inverse(&modulus, Some(&mut ctx)).unwrap();
+            let s = r.inverse(&modulus).unwrap();
 
-            let res = r.mod_mul(&s, &modulus, Some(&mut ctx)).unwrap();
+            let res = r.mod_mul(&s, &modulus).unwrap();
             assert_eq!(res, one);
         }
         let modulus = BigNumber::generate_prime(128)
             .unwrap()
-            .mul(&modulus, Some(&mut ctx))
+            .mul(&modulus)
             .unwrap();
         for _ in 0..25 {
             let r = BigNumber::rand(256).unwrap();
-            let s = r.inverse(&modulus, Some(&mut ctx)).unwrap();
+            let s = r.inverse(&modulus).unwrap();
 
-            let res = r.mod_mul(&s, &modulus, Some(&mut ctx)).unwrap();
+            let res = r.mod_mul(&s, &modulus).unwrap();
             assert_eq!(res, one);
         }
     }
@@ -195,15 +177,14 @@ mod tests {
     #[test]
     fn generate_prime_in_range_works() {
         let start = BIGNUMBER_2
-            .exp(&BigNumber::from_u32(RANGE_START).unwrap(), None)
+            .exp(&BigNumber::from_u32(RANGE_START).unwrap())
             .unwrap();
         let end = BIGNUMBER_2
-            .exp(&BigNumber::from_u32(RANGE_SIZE).unwrap(), None)
+            .exp(&BigNumber::from_u32(RANGE_SIZE).unwrap())
             .unwrap()
             .add(&start)
             .unwrap();
-        let random_prime =
-            BigNumber::generate_prime_in_range(RANGE_START, RANGE_SIZE, None).unwrap();
+        let random_prime = BigNumber::generate_prime_in_range(RANGE_START, RANGE_SIZE).unwrap();
         assert!(start < random_prime, "{start:?} >= {random_prime:?}");
         assert!(end >= random_prime, "{end:?} < {random_prime:?}");
     }
@@ -213,20 +194,20 @@ mod tests {
         let primes: Vec<u64> = vec![2, 23, 31, 42885908609, 24473809133, 47055833459];
         for pr in primes {
             let num = BigNumber::from_dec(&pr.to_string()).unwrap();
-            assert!(num.is_prime(None).unwrap());
+            assert!(num.is_prime().unwrap());
         }
         let num = BigNumber::from_dec("36").unwrap();
-        assert!(!num.is_prime(None).unwrap());
+        assert!(!num.is_prime().unwrap());
 
         let vec1 = vec![9, 252, 51, 8, 129]; // big endian representation of 42885908609
         let v1 = BigNumber::from_bytes(&vec1).unwrap();
-        assert!(v1.is_prime(None).unwrap());
+        assert!(v1.is_prime().unwrap());
         let vec2 = vec![129, 8, 51, 252, 9]; // little endian representation of 42885908609
         let v2 = BigNumber::from_bytes(&vec2).unwrap();
-        assert!(!v2.is_prime(None).unwrap());
+        assert!(!v2.is_prime().unwrap());
         let vec3 = vec![1, 153, 25]; // big endian representation of 104729
         let v3 = BigNumber::from_bytes(&vec3).unwrap();
-        assert!(v3.is_prime(None).unwrap());
+        assert!(v3.is_prime().unwrap());
     }
 
     #[test]
@@ -234,7 +215,7 @@ mod tests {
         let base = BigNumber::from_dec("12714671911903680502393098440562958150461307840092575886187217264492970515611166458444182780904860535776274190597528985988632488194981204988199325501696648896748368401254829974173258613724800116424602180755019588176641580062215499750550535543002990347313784260314641340394494547935943176226649412526659864646068220114536172189443925908781755710141006387091748541976715633668919725277837668568166444731358541327097786024076841158424402136565558677098853060675674958695935207345864359540948421232816012865873346545455513695413921957708811080877422273777355768568166638843699798663264533662595755767287970642902713301649").unwrap();
         let exp = BigNumber::from_dec("13991423645225256679625502829143442357836305738777175327623021076136862973228390317258480888217725740262243618881809894688804251512223982403225288178492105393953431042196371492402144120299046493467608097411259757604892535967240041988260332063962457178993277482991886508015739613530825229685281072180891075265116698114782553748364913010741387964956740720544998915158970813171997488129859542399633104746793770216517872705889857552727967921847493285577238").unwrap();
         let modulus = BigNumber::from_dec("991272771610724400277702356109350334773782112020672787325464582894874455338156617087078683660308327009158085342465983713825070967004447592080649030930737560915527173820649490032274245863850782844569456999473516497618489127293328524608584652323593452247534656999363158875176879817952982494174728640545484193154314433925648566686738628413929222467005197087738850212963801663981588243042912430590088435419451359859770426041670326127890520192033283832465411962274045956439947646966560440910244870464709982605844468449227905039953511431640780483761563845223213570597106855699997837768334871601402132694515676785338799407204529154456178837013845488372635042715003769626150545960460800980936426723680755798495767188398126674428244764038147226578038085253616108968402209263400729503458144370189359160926796812468410806201905992347006546335038212090539118675048292666041345556742530041533878341459110515497642054583635133581316796089099043782055893003258788369004899742992039315008110063759802733045648131896557338576682560236591353394201381103042167106112201578883917022695113857967398885475101031596068885337186646296664517159150904935112836318654117577507707562065113238913343761942585545093919444150946120523831367132144754209388110483749").unwrap();
-        let n = base.mod_exp(&exp, &modulus, None).unwrap();
+        let n = base.mod_exp(&exp, &modulus).unwrap();
         assert_eq!(n, BigNumber::from_dec("156669382818249607878298589043381544147555658222157929549484054385620519150887267126359684884641035264854247223281407349108771361611707714806192334779156374961296686821846487267487447347213829476609283133961216115764596907219173912888367998704856300105745961091899745329082513615681466199188236178266479183520370119131067362815102553237342546358580424556049196548520326206809677290296313839918774603549816182657993044271509706055893922152644469350618465711055733369291523796837304622919600074130968607301641438272377350795631212741686475924538423333008944556761300787668873766797549942827958501053262330421256183088509761636226277739400954175538503984519144969688787730088704522060486181427528150632576628856946041322195818246199503927686629821338146828603690778689292695518745939007886131151503766930229761608131819298276772877945842806872426029069949874062579870088710097070526608376602732627661781899595747063793310401032556802468649888104062151213860356554306295111191704764944574687548637446778783560586599000631975868701382113259027374431129732911012887214749014288413818636520182416636289308770657630129067046301651835893708731812616847614495049523221056260334965662875649480493232265453415256612460815802528012166114764216881").unwrap());
 
         let base = BigNumber::from_u32(6).unwrap();
@@ -242,23 +223,23 @@ mod tests {
         let modulus = BigNumber::from_u32(13).unwrap();
         assert_eq!(
             BigNumber::from_u32(7).unwrap(),
-            base.mod_exp(&exp, &modulus, None).unwrap()
+            base.mod_exp(&exp, &modulus,).unwrap()
         );
 
         let modulus = BigNumber::from_u32(0).unwrap();
-        assert!(base.mod_exp(&exp, &modulus, None).is_err());
+        assert!(base.mod_exp(&exp, &modulus,).is_err());
 
         let modulus = BigNumber::from_u32(5).unwrap().set_negative(true).unwrap();
         assert_eq!(
             BigNumber::from_u32(1).unwrap(),
-            base.mod_exp(&exp, &modulus, None).unwrap()
+            base.mod_exp(&exp, &modulus,).unwrap()
         );
     }
 
     #[test]
     fn modulus_works() {
         let base = BigNumber::from_u32(6).unwrap();
-        assert!(base.modulus(&BigNumber::new().unwrap(), None).is_err());
+        assert!(base.modulus(&BigNumber::new().unwrap(),).is_err());
 
         for (modulus, expected) in [
             (BigNumber::from_u32(1).unwrap(), BigNumber::new().unwrap()),
@@ -282,7 +263,7 @@ mod tests {
         ]
         .iter()
         {
-            assert_eq!(*expected, base.modulus(&modulus, None).unwrap());
+            assert_eq!(*expected, base.modulus(&modulus,).unwrap());
         }
     }
 
@@ -302,7 +283,7 @@ mod tests {
             let mut prime = BigNumber::from_dec(*p).unwrap();
             for _ in 1..*chain {
                 prime = prime.lshift1().unwrap().increment().unwrap();
-                assert!(prime.is_safe_prime(None).unwrap());
+                assert!(prime.is_safe_prime().unwrap());
             }
         }
     }
@@ -358,7 +339,7 @@ mod tests {
         // QR*_n.
         let mut a = BigNumber::from_dec("4").unwrap();
         assert_eq!(
-            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n, None),
+            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n,),
             Ok(true)
         );
 
@@ -369,7 +350,7 @@ mod tests {
         // hence it is not primitive in QR*_n
         a = BigNumber::from_dec("83826306846185295424745260846198095936").unwrap();
         assert_eq!(
-            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n, None),
+            a.generates_semiprime_subgroup(&p_prime, &q_prime, &n,),
             Ok(false)
         );
     }

--- a/src/bn/openssl.rs
+++ b/src/bn/openssl.rs
@@ -533,47 +533,6 @@ impl BigNumber {
         Ok(bn)
     }
 
-    pub fn generates_semiprime_subgroup(
-        &self,
-        p_prime: &BigNumber,
-        q_prime: &BigNumber,
-        n: &BigNumber,
-    ) -> ClResult<bool> {
-        // Returns true if and only if self is a generator for a
-        // multiplicative subgroup of the integers mod n of order
-        // p'*q' where n = (2p' + 1) * (2q' + 1)
-
-        // Can be used to check if an invertible quadratic residue of
-        // an RSA modulus n is a generator for the whole group of
-        // invertible quadratic residues mod n
-
-        let big_one = BigNumber::from_u32(1)?;
-
-        if self == &big_one
-            || self.mod_exp(p_prime, &n, None)? == big_one
-            || self.mod_exp(q_prime, &n, None)? == big_one
-        {
-            return Ok(false);
-        }
-
-        Ok(true)
-    }
-
-    pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
-        let mut sqr_candidate = n.rand_range()?;
-        let big_one = BigNumber::from_u32(1)?;
-
-        // Number sqr_candidate to square must be between 1 and n-1 and
-        // have gcd(sqr_candidate,n)=1
-        while Self::gcd(&sqr_candidate, n, None)? != big_one {
-            sqr_candidate = n.rand_range()?;
-        }
-
-        let qr = sqr_candidate.sqr(None)?.modulus(n, None)?;
-
-        Ok(qr)
-    }
-
     // Question: Why does this need to be a Result? When is creating a BigNumber same as another
     // BigNumber not possible given sufficient memory?
     pub fn try_clone(&self) -> ClResult<BigNumber> {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -28,11 +28,11 @@ pub const LARGE_ALPHATILDE: usize = 2787;
 // Constants that are used throughout the CL signatures code, so avoiding recomputation.
 pub static LARGE_E_START_VALUE: Lazy<BigNumber> = Lazy::new(|| {
     BIGNUMBER_2
-        .exp(&BigNumber::from_u32(LARGE_E_START).unwrap(), None)
+        .exp(&BigNumber::from_u32(LARGE_E_START).unwrap())
         .unwrap()
 });
 pub static LARGE_VPRIME_PRIME_VALUE: Lazy<BigNumber> = Lazy::new(|| {
     BIGNUMBER_2
-        .exp(&BigNumber::from_u32(LARGE_VPRIME_PRIME - 1).unwrap(), None)
+        .exp(&BigNumber::from_u32(LARGE_VPRIME_PRIME - 1).unwrap())
         .unwrap()
 });

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::cell::RefCell;
 
 use crate::amcl::{GroupOrderElement, Pair, PointG1};
-use crate::bn::{BigNumber, BigNumberContext, _generate_prime_in_range, BIGNUMBER_1};
+use crate::bn::{BigNumber, BigNumberContext, BIGNUMBER_1};
 use crate::constants::*;
 use crate::error::Result as ClResult;
 use crate::hash::{hash_to_bignum, ByteOrder};
@@ -35,8 +35,8 @@ impl MockHelper {
     }
 }
 
-#[cfg(test)]
 pub fn bn_rand(size: usize) -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         return match size {
             LARGE_NONCE => Ok(BigNumber::from_dec("526193306511429638192053")?),
@@ -56,15 +56,7 @@ pub fn bn_rand(size: usize) -> ClResult<BigNumber> {
             }
         };
     }
-    _bn_rand(size)
-}
 
-#[cfg(not(test))]
-pub fn bn_rand(size: usize) -> ClResult<BigNumber> {
-    _bn_rand(size)
-}
-
-pub fn _bn_rand(size: usize) -> ClResult<BigNumber> {
     trace!("Helpers::bn_rand: >>> size:: {:?}", size);
 
     let res = BigNumber::rand(size)?;
@@ -74,17 +66,12 @@ pub fn _bn_rand(size: usize) -> ClResult<BigNumber> {
     Ok(res)
 }
 
-#[cfg(test)]
-pub fn bn_rand_range(_bn: &BigNumber) -> ClResult<BigNumber> {
-    BigNumber::from_dec("6355086599653879826316700099928903465759924565682653297540990486160410136991969646604012568191576052570982028627086748382054319397088948628665022843282950799083156383516421449932691541760677147872377591267323656783938723945915297920233965100454678367417561768144216659060966399182536425206811620699453941460281449071103436526749575365638254352831881150836568830779323361579590121888491911166612382507532248659384681554612887580241255323056245170208421770819447066550669981130450421507202133758209950007973511221223647764045990479619451838104977691662868482078262695232806059726002249095643117917855811948311863670130")
-}
-
-#[cfg(not(test))]
 pub fn bn_rand_range(bn: &BigNumber) -> ClResult<BigNumber> {
-    _bn_rand_range(bn)
-}
+    #[cfg(test)]
+    if MockHelper::is_injected() {
+        return  BigNumber::from_dec("6355086599653879826316700099928903465759924565682653297540990486160410136991969646604012568191576052570982028627086748382054319397088948628665022843282950799083156383516421449932691541760677147872377591267323656783938723945915297920233965100454678367417561768144216659060966399182536425206811620699453941460281449071103436526749575365638254352831881150836568830779323361579590121888491911166612382507532248659384681554612887580241255323056245170208421770819447066550669981130450421507202133758209950007973511221223647764045990479619451838104977691662868482078262695232806059726002249095643117917855811948311863670130");
+    }
 
-pub fn _bn_rand_range(bn: &BigNumber) -> ClResult<BigNumber> {
     trace!("Helpers::bn_rand_range: >>> bn:: {:?}", bn);
 
     let res = bn.rand_range()?;
@@ -114,20 +101,12 @@ pub fn hash_credential_attribute(attribute: &str) -> ClResult<String> {
     encode_attribute(attribute, ByteOrder::Big)?.to_dec()
 }
 
-#[cfg(test)]
 pub fn generate_v_prime_prime() -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         return BigNumber::from_dec("6620937836014079781509458870800001917950459774302786434315639456568768602266735503527631640833663968617512880802104566048179854406925811731340920442625764155409951969854303612644125623549271204625894424804352003689903192473464433927658013251120302922648839652919662117216521257876025436906282750361355336367533874548955283776610021309110505377492806210342214471251451681722267655419075635703240258044336607001296052867746675049720589092355650996711033859489737240617860392914314205277920274997312351322125481593636904917159990500837822414761512231315313922792934655437808723096823124948039695324591344458785345326611693414625458359651738188933757751726392220092781991665483583988703321457480411992304516676385323318285847376271589157730040526123521479652961899368891914982347831632139045838008837541334927738208491424027");
     }
-    _generate_v_prime_prime()
-}
 
-#[cfg(not(test))]
-pub fn generate_v_prime_prime() -> ClResult<BigNumber> {
-    _generate_v_prime_prime()
-}
-
-pub fn _generate_v_prime_prime() -> ClResult<BigNumber> {
     trace!("Helpers::generate_v_prime_prime: >>>");
 
     let a = bn_rand(LARGE_VPRIME_PRIME)?;
@@ -142,21 +121,21 @@ pub fn _generate_v_prime_prime() -> ClResult<BigNumber> {
     Ok(v_prime_prime)
 }
 
-#[cfg(test)]
-pub fn generate_prime_in_range(size_bits: usize, range_bits: usize) -> ClResult<BigNumber> {
+pub fn generate_prime_in_range(
+    size_bits: usize,
+    range_bits: usize,
+    ctx: Option<&mut BigNumberContext>,
+) -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         return BigNumber::from_dec("259344723055062059907025491480697571938277889515152306249728583105665800713306759149981690559193987143012367913206299323899696942213235956742930201588264091397308910346117473868881");
     }
-    _generate_prime_in_range(size_bits, range_bits)
+
+    BigNumber::generate_prime_in_range(size_bits, range_bits, ctx)
 }
 
-#[cfg(not(test))]
-pub fn generate_prime_in_range(size_bits: usize, range_bits: usize) -> ClResult<BigNumber> {
-    _generate_prime_in_range(size_bits, range_bits)
-}
-
-#[cfg(test)]
 pub fn generate_safe_prime(size: usize) -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         match size {
             LARGE_PRIME => return Ok(BigNumber::from_dec("298425477551432359319017298068281828134535746771300905126443720735756534287270383542467183175737460443806952398210045827718115111810885752229119677470711305345901926067944629292942471551423868488963517954094239606951758940767987427212463600313901180668176172283994206392965011112962119159458674722785709556623")?),
@@ -165,15 +144,7 @@ pub fn generate_safe_prime(size: usize) -> ClResult<BigNumber> {
             }
         }
     }
-    _generate_safe_prime(size)
-}
 
-#[cfg(not(test))]
-pub fn generate_safe_prime(size: usize) -> ClResult<BigNumber> {
-    _generate_safe_prime(size)
-}
-
-pub fn _generate_safe_prime(size: usize) -> ClResult<BigNumber> {
     trace!("Helpers::generate_safe_prime: >>> size: {:?}", size);
 
     let safe_prime = BigNumber::generate_safe_prime(size)?;
@@ -186,23 +157,19 @@ pub fn _generate_safe_prime(size: usize) -> ClResult<BigNumber> {
     Ok(safe_prime)
 }
 
-#[cfg(test)]
-pub fn gen_x(p: &BigNumber, q: &BigNumber) -> ClResult<BigNumber> {
+pub fn gen_x(
+    p: &BigNumber,
+    q: &BigNumber,
+    ctx: Option<&mut BigNumberContext>,
+) -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         return BigNumber::from_dec("21756443327382027172985704617047967597993694788495380290694324827806324727974811069286883097008098972826137846700650885182803802394920367284736320514617598740869006348763668941791139304299497512001555851506177534398138662287596439312757685115968057647052806345903116050638193978301573172649243964671896070438965753820826200974052042958554415386005813811429117062833340444950490735389201033755889815382997617514953672362380638953231325483081104074039069074312082459855104868061153181218462493120741835250281211598658590317583724763093211076383033803581749876979865965366178002285968278439178209181121479879436785731938");
     }
-    _gen_x(p, q)
-}
 
-#[cfg(not(test))]
-pub fn gen_x(p: &BigNumber, q: &BigNumber) -> ClResult<BigNumber> {
-    _gen_x(p, q)
-}
-
-pub fn _gen_x(p: &BigNumber, q: &BigNumber) -> ClResult<BigNumber> {
     trace!("Helpers::gen_x: >>> p: {:?}, q: {:?}", p, q);
 
-    let mut x = p.mul(q, None)?.sub_word(3)?.rand_range()?;
+    let mut x = p.mul(q, ctx)?.sub_word(3)?.rand_range()?;
 
     x.add_word(2)?;
 
@@ -211,27 +178,13 @@ pub fn _gen_x(p: &BigNumber, q: &BigNumber) -> ClResult<BigNumber> {
     Ok(x)
 }
 
-#[cfg(test)]
-pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
+pub fn random_qr(n: &BigNumber, ctx: Option<&mut BigNumberContext>) -> ClResult<BigNumber> {
+    #[cfg(test)]
     if MockHelper::is_injected() {
         return BigNumber::from_dec("64684820421150545443421261645532741305438158267230326415141505826951816460650437611148133267480407958360035501128469885271549378871140475869904030424615175830170939416512594291641188403335834762737251794282186335118831803135149622404791467775422384378569231649224208728902565541796896860352464500717052768431523703881746487372385032277847026560711719065512366600220045978358915680277126661923892187090579302197390903902744925313826817940566429968987709582805451008234648959429651259809188953915675063700676546393568304468609062443048457324721450190021552656280473128156273976008799243162970386898307404395608179975243");
     }
-    _random_qr(n)
-}
 
-#[cfg(not(test))]
-pub fn random_qr(n: &BigNumber) -> ClResult<BigNumber> {
-    _random_qr(n)
-}
-
-pub fn _random_qr(n: &BigNumber) -> ClResult<BigNumber> {
-    trace!("Helpers::random_qr: >>> n: {:?}", n);
-
-    let qr = BigNumber::random_qr(n)?;
-
-    trace!("Helpers::random_qr: <<< qr: {:?}", qr);
-
-    Ok(qr)
+    BigNumber::random_qr(n, ctx)
 }
 
 //TODO: FIXME very inefficient code


### PR DESCRIPTION
- Avoid duplication of `generates_semiprime_subgroup` and `random_qr` across bignum backends
- Eliminate use of BigNumContext outside of the openssl backend (always use a thread-local context)