### PR TITLE
Update version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "ee5cca1ddc8b9dceb55b7f1272a9d1e643d73006f350a20ab4926d24e33f0f0d"
 
 [[package]]
 name = "anoncreds-clsignatures"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "amcl",
  "glass_pumpkin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "anoncreds-clsignatures"
 readme = "README.md"
 repository = "https://github.com/hyperledger/anoncreds-clsignatures-rs"
-version = "0.2.4"
+version = "0.3.0"
 rust-version = "1.63"
 
 [lib]

--- a/src/amcl.rs
+++ b/src/amcl.rs
@@ -144,11 +144,13 @@ impl PointG1 {
     }
 
     /// Encode to hexadecimal format
+    #[allow(unused)]
     pub fn to_string(&self) -> ClResult<String> {
         Ok(self.point.to_hex())
     }
 
     /// Decode from hexadecimal format
+    #[allow(unused)]
     pub fn from_string(val: &str) -> ClResult<Self> {
         let res = Self::from_string_inf(val)?;
         if res.is_inf()? {
@@ -671,10 +673,12 @@ impl Pair {
         Ok(self.pair.isunity())
     }
 
+    #[allow(unused)]
     pub fn to_string(&self) -> ClResult<String> {
         Ok(self.pair.to_hex())
     }
 
+    #[allow(unused)]
     pub fn from_string(val: &str) -> ClResult<Pair> {
         pre_validate_point(val, 12)?;
         let pair = FP12::from_hex(val.to_string());
@@ -692,6 +696,7 @@ impl Pair {
         Ok(vec)
     }
 
+    #[allow(unused)]
     pub fn from_bytes(b: &[u8]) -> ClResult<Self> {
         if b.len() != Self::BYTES_REPR_SIZE {
             Err(err_msg!("Invalid byte length for Pair"))


### PR DESCRIPTION
Also cleans up a few warnings when the `serde` feature is disabled.